### PR TITLE
Add unit tests and SQLite config

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
+import sys
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -86,6 +87,15 @@ DATABASES = {
         "PORT": os.getenv("POSTGRES_PORT"),
     }
 }
+
+# Simplify database configuration when running tests
+if 'test' in sys.argv:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'test_db.sqlite3',
+        }
+    }
 
 
 # Password validation

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,75 @@
+from datetime import date
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import (
+    Department,
+    Position,
+    Employee,
+    WorkSchedule,
+    Service,
+    EmployeeServiceRecord,
+)
+
+
+class TimesheetViewTests(TestCase):
+    def setUp(self):
+        self.department = Department.objects.create(name="Dep")
+        self.position = Position.objects.create(name="Worker")
+        self.employee = Employee.objects.create(
+            full_name="John Doe",
+            department=self.department,
+            position=self.position,
+        )
+
+    def test_get_timesheet(self):
+        url = reverse("timesheet") + "?month=2024-01"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.employee, list(response.context["employees"]))
+
+    def test_post_timesheet_creates_schedule(self):
+        month = date.today().strftime("%Y-%m")
+        url = reverse("timesheet") + f"?month={month}"
+        resp = self.client.post(url, {f"shift_{self.employee.id}_1": "day"})
+        self.assertEqual(resp.status_code, 302)
+        month_first = date.today().replace(day=1)
+        self.assertTrue(
+            WorkSchedule.objects.filter(
+                employee=self.employee, date=month_first, shift="day"
+            ).exists()
+        )
+
+
+class ServicesViewTests(TestCase):
+    def setUp(self):
+        self.department = Department.objects.create(name="Dep")
+        self.position = Position.objects.create(name="Worker")
+        self.employee = Employee.objects.create(
+            full_name="John Doe",
+            department=self.department,
+            position=self.position,
+            is_fixed_salary=False,
+        )
+        self.service = Service.objects.create(
+            name="Test Service", price=100, for_salary_based=False
+        )
+
+    def test_get_services(self):
+        url = reverse("services") + "?month=2024-01"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.service, list(response.context["services"]))
+
+    def test_post_services_creates_record(self):
+        month = date.today().strftime("%Y-%m")
+        url = reverse("services") + f"?month={month}"
+        resp = self.client.post(
+            url, {f"s_{self.employee.id}_{self.service.id}": "2"}
+        )
+        self.assertEqual(resp.status_code, 302)
+        month_first = date.today().replace(day=1)
+        record = EmployeeServiceRecord.objects.get(
+            employee=self.employee, service=self.service, month=month_first
+        )
+        self.assertEqual(record.quantity, 2)


### PR DESCRIPTION
## Summary
- configure settings to use SQLite during tests
- add basic tests for `timesheet_view` and `services_view`

## Testing
- `python manage.py test --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878f0e4af28832e8d16673c0cd88d32