### PR TITLE
Configure secret key via env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 DEBUG=True
-DJANGO_SECRET_KEY=your-secret-key
+DJANGO_SECRET_KEY=unsafe-secret
 POSTGRES_DB=timesheet
 POSTGRES_USER=timesheet_user
 POSTGRES_PASSWORD=secret

--- a/config/settings.py
+++ b/config/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-#01$-h&ba99zvfv_gi3l=rvvl_$oi-r*=wm^#osm5n&&5-mao0'
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "unsafe-secret")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- load `DJANGO_SECRET_KEY` from environment in settings
- update `.env` with `DJANGO_SECRET_KEY` placeholder

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878f0d7e9a0832ebf2e1c3278875309