### PR TITLE
Fix redundant Department import

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -32,7 +32,6 @@ def parse_month(request):
 
 
 def timesheet_view(request):
-    from .models import Department  # добавим импорт, если ещё не был
 
     first_day = parse_month(request)
     year, month = first_day.year, first_day.month


### PR DESCRIPTION
## Summary
- remove local `Department` import from `timesheet_view`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878f0d2abf8832eaa59f66835bfbec3