### PR TITLE
Fix duplicate URL names for salary exports

### DIFF
--- a/core/templates/core/report.html
+++ b/core/templates/core/report.html
@@ -85,7 +85,7 @@
   📥 Выгрузить Аванс
 </a>
 
-<a href="{% url 'export_salary_report' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
+<a href="{% url 'export_salary_full' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
    class="inline-block px-5 py-2 bg-green-600 text-white rounded hover:bg-green-700 font-semibold shadow">
   📥 Выгрузить Зарплату
 </a>

--- a/core/urls.py
+++ b/core/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path("report/export/", export_salary_report_xlsx, name="export_salary_report"),
     path("report/", report_view, name="report"),
     path("export-advance/", export_salary_advance_xlsx, name="export_salary_advance"),
-    path("export-salary/", export_salary_full_xlsx, name="export_salary_report"),
+    path("export-salary/", export_salary_full_xlsx, name="export_salary_full"),
 ]


### PR DESCRIPTION
## Summary
- give the `export-salary` route its own name
- update salary export link in the report template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878f0c79a10832eac21967388bde99d