### PR TITLE
Implement final payroll calculation

### DIFF
--- a/core/templates/core/report.html
+++ b/core/templates/core/report.html
@@ -76,7 +76,13 @@
 
 <!-- Выгрузка -->
 <div class="mt-6">
-  <a href="{% url 'export_salary_report' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
+  {% if report_type == 'advance' %}
+  <a href="{% url 'export_salary_advance' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
+  {% elif report_type == 'final' %}
+  <a href="{% url 'export_salary_final' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
+  {% else %}
+  <a href="{% url 'export_salary_full' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
+  {% endif %}
      class="inline-block px-5 py-2 bg-green-600 text-white rounded hover:bg-green-700 font-semibold shadow">
     📥 Выгрузить Excel-отчёт
   </a>

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,6 +8,7 @@ from .views import (
     report_view,
     export_salary_full_xlsx,
     export_salary_advance_xlsx,
+    export_salary_final_xlsx,
 )
 
 urlpatterns = [
@@ -19,4 +20,5 @@ urlpatterns = [
     path("report/", report_view, name="report"),
     path("export-advance/", export_salary_advance_xlsx, name="export_salary_advance"),
     path("export-salary/", export_salary_full_xlsx, name="export_salary_full"),
+    path("export-final/", export_salary_final_xlsx, name="export_salary_final"),
 ]


### PR DESCRIPTION
## Summary
- support final salary calculation in reports and Excel export
- allow exporting final payroll
- adjust report template for dynamic Excel links
- test final salary deduction logic

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a02f3983c832eaba931c6b6af6940