### PR TITLE
Add schedule templates

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2,7 +2,16 @@ from django.contrib import admin
 from django.urls import path
 from django.shortcuts import render, redirect
 from django.contrib import messages
-from .models import Department, Position, Employee, WorkSchedule, Service, EmployeeServiceRecord, Settings
+from .models import (
+    Department,
+    Position,
+    Employee,
+    WorkSchedule,
+    Service,
+    EmployeeServiceRecord,
+    Settings,
+    ScheduleTemplate,
+)
 import openpyxl
 
 @admin.register(Department)
@@ -72,3 +81,8 @@ class EmployeeAdmin(admin.ModelAdmin):
 @admin.register(Settings)
 class SettingsAdmin(admin.ModelAdmin):
     list_display = ("partial_shift_multiplier", "vacation_multiplier", "sick_multiplier")
+
+
+@admin.register(ScheduleTemplate)
+class ScheduleTemplateAdmin(admin.ModelAdmin):
+    list_display = ("name",)

--- a/core/migrations/0007_scheduletemplate.py
+++ b/core/migrations/0007_scheduletemplate.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_remove_department_partial_day_rate_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ScheduleTemplate',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, verbose_name='Название шаблона')),
+                ('sequence', models.JSONField(verbose_name='Последовательность смен')),
+            ],
+            options={
+                'verbose_name': 'Шаблон графика',
+                'verbose_name_plural': 'Шаблоны графиков',
+            },
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -93,3 +93,15 @@ class Settings(models.Model):
     @classmethod
     def get(cls):
         return cls.objects.first() or cls.objects.create()
+
+
+class ScheduleTemplate(models.Model):
+    name = models.CharField(max_length=100, verbose_name="Название шаблона")
+    sequence = models.JSONField(verbose_name="Последовательность смен")
+
+    class Meta:
+        verbose_name = "Шаблон графика"
+        verbose_name_plural = "Шаблоны графиков"
+
+    def __str__(self):
+        return self.name

--- a/core/templates/core/timesheet.html
+++ b/core/templates/core/timesheet.html
@@ -105,9 +105,9 @@
   <div class="bg-white p-6 rounded shadow-lg w-[300px]">
     <h2 class="text-lg font-bold mb-4">Выберите шаблон графика</h2>
     <select id="schedule-template" class="w-full border px-2 py-1 mb-4">
-      <option value="2_2">2/2 (день/день/вых/вых)</option>
-      <option value="5_2">5/2 (пн–пт — день, сб/вс — выходной)</option>
-      <option value="night_3_3">3/3 (ночь/ночь/ночь/вых/вых/вых)</option>
+      {% for tpl in schedule_templates %}
+      <option value="{{ tpl.id }}">{{ tpl.name }}</option>
+      {% endfor %}
     </select>
     <div class="flex justify-end space-x-2">
       <button onclick="closeAutoFillModal()" class="text-gray-600">Отмена</button>
@@ -122,6 +122,7 @@ const lastShifts = {
     {{ emp.id }}: "{{ last_shifts|get_item:emp.id|default_if_none:'' }}",
   {% endfor %}
 };
+const templates = {{ templates_json|safe }};
 
 document.addEventListener("DOMContentLoaded", function () {
   document.querySelectorAll(".shift-button").forEach(button => {
@@ -157,34 +158,21 @@ function closeAutoFillModal() {
   document.getElementById("autofill-modal").classList.add("hidden");
 }
 function applyAutoFill() {
-  const template = document.getElementById("schedule-template").value;
-  const monthStart = "{{ month|date:'Y-m' }}";
-  const labelMap = { day: "Д", night: "Н", weekend: "В", vacation: "О", sick: "Б" };
+  const templateId = document.getElementById("schedule-template").value;
+  const sequence = templates[templateId] || [];
+  const labelMap = { day: "Д", night: "Н", weekend: "В", vacation: "О", sick: "Б", partial: "Нп" };
 
   document.querySelectorAll("input[name^='shift_']").forEach(input => {
     const parts = input.name.split("_");
     const empId = parts[1];
     const day = parseInt(parts[2]);
 
-    let shift = "";
     let offset = 0;
-
-    if (template === "2_2") {
-      const cycle = ["day", "day", "weekend", "weekend"];
-      const prev = lastShifts[empId];
-      offset = cycle.includes(prev) ? (cycle.indexOf(prev) + 1) % cycle.length : 0;
-      shift = cycle[(offset + day - 1) % cycle.length];
+    const prev = lastShifts[empId];
+    if (sequence.includes(prev)) {
+      offset = (sequence.indexOf(prev) + 1) % sequence.length;
     }
-    if (template === "5_2") {
-      const d = new Date(`${monthStart}-${String(day).padStart(2, '0')}`);
-      shift = (d.getDay() === 0 || d.getDay() === 6) ? "weekend" : "day";
-    }
-    if (template === "night_3_3") {
-      const cycle = ["night", "night", "night", "weekend", "weekend", "weekend"];
-      const prev = lastShifts[empId];
-      offset = cycle.includes(prev) ? (cycle.indexOf(prev) + 1) % cycle.length : 0;
-      shift = cycle[(offset + day - 1) % cycle.length];
-    }
+    const shift = sequence.length ? sequence[(offset + day - 1) % sequence.length] : "";
 
     input.value = shift;
     const button = input.parentElement.querySelector(".shift-button");

--- a/core/tests.py
+++ b/core/tests.py
@@ -9,6 +9,7 @@ from .models import (
     WorkSchedule,
     Service,
     EmployeeServiceRecord,
+    ScheduleTemplate,
 )
 
 
@@ -39,6 +40,13 @@ class TimesheetViewTests(TestCase):
                 employee=self.employee, date=month_first, shift="day"
             ).exists()
         )
+
+    def test_schedule_templates_in_context(self):
+        ScheduleTemplate.objects.create(name="2/2", sequence=["day", "day", "weekend", "weekend"])
+        url = reverse("timesheet") + "?month=2024-01"
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("schedule_templates", resp.context)
 
 
 class ServicesViewTests(TestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -29,6 +29,7 @@ from .models import (
     Service,
     EmployeeServiceRecord,
     Department,
+    ScheduleTemplate,
 )
 
 
@@ -87,6 +88,8 @@ def timesheet_view(request):
         }
 
     departments = Department.objects.all()
+    templates = list(ScheduleTemplate.objects.all())
+    templates_json = {t.id: t.sequence for t in templates}
     return render(request, "core/timesheet.html", {
         "employees": employees,
         "days": range(1, days_in_month + 1),
@@ -104,6 +107,8 @@ def timesheet_view(request):
         "departments": departments,
         "selected_department": department_id,
         "last_shifts": last_shift_map,
+        "schedule_templates": templates,
+        "templates_json": templates_json,
     })
 
 


### PR DESCRIPTION
## Summary
- create `ScheduleTemplate` model for storing shift sequences
- expose templates in the timesheet view and page
- add admin registration
- adjust JavaScript autofill logic
- include basic unit test

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a3dec3d8c832e9403e7be40d969ed