### PR TITLE
Fix report template filter loading

### DIFF
--- a/core/templates/core/report.html
+++ b/core/templates/core/report.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load custom_filters %}
 
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-4">


### PR DESCRIPTION
## Summary
- load `custom_filters` in the report template so custom tags work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a54203418832e9633aad42a7721c5