### PR TITLE
Add import for timesheet

### DIFF
--- a/core/templates/core/import_timesheet.html
+++ b/core/templates/core/import_timesheet.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Импорт табеля{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Импорт табеля за {{ month|date:"F Y" }}</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  {% csrf_token %}
+  <input type="file" name="xlsx_file" accept=".xlsx" required class="border px-2 py-1 rounded" />
+  <button type="submit" class="px-4 py-2 bg-orange-600 text-white rounded hover:bg-orange-700">Загрузить</button>
+</form>
+<p class="mt-4 text-sm text-gray-700">Формат: первая колонка ФИО, далее колонки <code>01</code>, <code>02</code> ... с кодами смен (Д, Н, В, О, Б, П).</p>
+{% endblock %}

--- a/core/templates/core/timesheet.html
+++ b/core/templates/core/timesheet.html
@@ -117,6 +117,8 @@
     <button type="submit" class="px-4 py-2 bg-[var(--bianca-orange)] text-white rounded hover:bg-orange-600">💾 Сохранить табель</button>
     <a href="{% url 'export_timesheet' %}?month={{ month|date:'Y-m' }}{% if selected_department %}&department={{ selected_department }}{% endif %}"
        class="ml-4 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">📥 Выгрузить в Excel</a>
+    <a href="{% url 'import_timesheet' %}?month={{ month|date:'Y-m' }}"
+       class="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">⬆ Импорт из Excel</a>
   </div>
 </form>
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from .views import (
     timesheet_view,
     export_timesheet_xlsx,
+    import_timesheet_view,
     services_view,
     export_services_xlsx,
     export_salary_report_xlsx,
@@ -12,6 +13,7 @@ from .views import (
 
 urlpatterns = [
     path("timesheet/", timesheet_view, name="timesheet"),
+    path("timesheet/import/", import_timesheet_view, name="import_timesheet"),
     path("timesheet/export/", export_timesheet_xlsx, name="export_timesheet"),
     path("services/", services_view, name="services"),
     path("services/export/", export_services_xlsx, name="export_services"),


### PR DESCRIPTION
## Summary
- implement `import_timesheet_view` to load shifts from Excel
- add route `timesheet/import/`
- provide upload page and navigation link

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a601d4b04832eb73e12772b401ce0