### PR TITLE
Add analytics view

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -54,6 +54,10 @@
            class="px-4 py-2 rounded font-medium text-sm {% if 'report' in current_path %}bianca-active{% else %}bianca-inactive{% endif %}">
           💰 Финальный расчёт
         </a>
+        <a href="{% url 'analytics' %}?month={{ month|date:'Y-m' }}"
+           class="px-4 py-2 rounded font-medium text-sm {% if 'analytics' in current_path %}bianca-active{% else %}bianca-inactive{% endif %}">
+          📊 Аналитика
+        </a>
       {% endwith %}
     </div>
 

--- a/core/templates/core/analytics.html
+++ b/core/templates/core/analytics.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% block title %}Аналитика{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold text-gray-900 mb-4">Аналитика за {{ month|date:"F Y" }}</h1>
+
+<form method="get" class="mb-6 flex flex-wrap gap-4 items-center">
+  <label class="font-semibold text-gray-800">Месяц:
+    <input type="month" name="month" value="{{ month|date:'Y-m' }}"
+           class="border rounded px-2 py-1 text-sm shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500">
+  </label>
+  <button type="submit"
+          class="px-4 py-1 bg-orange-600 text-white rounded hover:bg-orange-700 text-sm font-semibold shadow">
+    Показать
+  </button>
+</form>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Смены по отделам</h2>
+<div class="overflow-x-auto border rounded shadow-sm mb-6">
+  {{ shift_table|safe }}
+</div>
+<canvas id="shiftsChart" class="max-w-3xl mb-8"></canvas>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Услуги по отделам</h2>
+<div class="overflow-x-auto border rounded shadow-sm mb-6">
+  {{ service_table|safe }}
+</div>
+<canvas id="servicesChart" class="max-w-3xl mb-8"></canvas>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const shiftData = {{ shift_chart|safe }};
+const serviceData = {{ service_chart|safe }};
+
+if (shiftData && document.getElementById('shiftsChart')) {
+  const ctx = document.getElementById('shiftsChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: Object.keys(shiftData),
+      datasets: [{
+        label: 'Смен всего',
+        data: Object.values(shiftData),
+        backgroundColor: '#ff4b00'
+      }]
+    },
+    options: {responsive: true}
+  });
+}
+
+if (serviceData && document.getElementById('servicesChart')) {
+  const ctx = document.getElementById('servicesChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: Object.keys(serviceData),
+      datasets: [{
+        label: 'Услуг всего',
+        data: Object.values(serviceData),
+        backgroundColor: '#00aaff'
+      }]
+    },
+    options: {responsive: true}
+  });
+}
+</script>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,6 +8,7 @@ from .views import (
     report_view,
     export_salary_full_xlsx,
     export_salary_advance_xlsx,
+    analytics_view,
 )
 
 urlpatterns = [
@@ -19,4 +20,5 @@ urlpatterns = [
     path("report/", report_view, name="report"),
     path("export-advance/", export_salary_advance_xlsx, name="export_salary_advance"),
     path("export-salary/", export_salary_full_xlsx, name="export_salary_full"),
+    path("analytics/", analytics_view, name="analytics"),
 ]


### PR DESCRIPTION
## Summary
- add new pandas-based analytics view
- expose analytics URL and template with tables & charts
- link analytics page in navigation

## Testing
- `pytest core/tests.py::TimesheetViewTests::test_get_timesheet -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a60203338832e831178c3da629935